### PR TITLE
Fix head files

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Project0861</title>
-  <link rel="stylesheet" href="//libs.cartocdn.com/cartodb.js/v3/themes/css/cartodb.css" />
-  <script src="//libs.cartocdn.com/cartodb.js/v3/cartodb.js"></script>
+  <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/themes/css/cartodb.css" />
+  <script src="http://libs.cartocdn.com/cartodb.js/v3/cartodb.js"></script>
   <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag    'application', media: 'all' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>Project0861</title>
-  <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/themes/css/cartodb.css" />
-  <script src="http://libs.cartocdn.com/cartodb.js/v3/cartodb.js"></script>
+  <link rel="stylesheet" href="//libs.cartocdn.com/cartodb.js/v3/themes/css/cartodb.css" />
+  <script src="//libs.cartocdn.com/cartodb.js/v3/cartodb.js"></script>
   <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag    'application', media: 'all' %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Enabling config.force_ssl = false 
Helps to fix Heroku needing our external CSS and JS files needing to be on an HTTPS route. 
